### PR TITLE
Fix 'unresolved vtable' link error

### DIFF
--- a/clients/cpp11_client/client/client.pro
+++ b/clients/cpp11_client/client/client.pro
@@ -12,4 +12,7 @@ TEMPLATE = app
 SOURCES += main.cpp
 
 HEADERS += \
-
+    core/api.h \
+    core/base_strategy.h \
+    core/client.h \
+    core/strategy.h


### PR DESCRIPTION
Из-за того, что в файле проекта не были указаны заголовочные файлы, qmoc не обрабатывал их и не генерировал соответсвующие файлы с классами, вследствие чего линковщик не мог найти виртуальный конструктор/деструктор класса Client.