### PR TITLE
Remove elevator from passenger while exiting

### DIFF
--- a/localrunner/world/core/game_objects/passenger.py
+++ b/localrunner/world/core/game_objects/passenger.py
@@ -208,6 +208,7 @@ class Passenger(object):
                 self.state = self.PASSENGER_STATE['walking_on_floor']
                 self.from_floor = self.floor
                 self.dest_floor = self.floors_queue.pop(0)
+                self.elevator = None
                 return
 
             self.move(x=sign(self.x))


### PR DESCRIPTION
Сейчас не зануляется лифт у пассажира при выходе из лифта и он возвращается с этажа с заданным лифтом (тем, из которого вышел) в состоянии waiting_for_elevator. 
Если в первый тик, после его возвращения с этажа ему не задать лифт, то на следующий тик он перейдет в состояние moving_to_elevator, причем независимо от того, на каком этаже этот лифт. Если лифт на другом, то только на третий тик он перейдет returning с has_elevator==fasle